### PR TITLE
Add step to conditionally skip contract commands

### DIFF
--- a/.github/workflows/check-contracts-and-assets.yml
+++ b/.github/workflows/check-contracts-and-assets.yml
@@ -11,7 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Validate Data Contracts'
     steps:
+      # By default, the Gable CLI will exit with a non-zero exit code if no contracts are found when calling the
+      # validate or publish command. For this tutorial, there won't be any contracts in the repo to start, so we
+      # need this extra step to check if we should skip validation
+      - shell: bash
+        run: |
+          if ls ./contracts/*.yaml 1> /dev/null 2>&1; then
+              echo "Found contract files, running validation..."
+          else
+              echo "No contract files found, skipping contract validation..."
+              echo SKIP_VALIDATION=true >> $GITHUB_ENV
+          fi
       - name: Validate Contracts
+        if: ${{ env.SKIP_VALIDATION  != 'true' }}
         uses: gabledata/cicd/github-actions/validate-contracts@latest
         with:
           # Provide API key secret, and endpoint variable created in previous steps

--- a/.github/workflows/publish-contracts-and-assets.yml
+++ b/.github/workflows/publish-contracts-and-assets.yml
@@ -14,7 +14,19 @@ jobs:
     name: 'Validate & Publish Contracts'
     needs: [register-data-assets]
     steps:
+      # By default, the Gable CLI will exit with a non-zero exit code if no contracts are found when calling the
+      # validate or publish command. For this tutorial, there won't be any contracts in the repo to start, so we
+      # need this extra step to check if we should skip validation
+      - shell: bash
+        run: |
+          if ls ./contracts/*.yaml 1> /dev/null 2>&1; then
+              echo "Found contract files, publishing contracts..."
+          else
+              echo "No contract files found, skipping contract validation..."
+              echo SKIP_VALIDATION=true >> $GITHUB_ENV
+          fi
       - name: Validate Contracts
+        if: ${{ env.SKIP_VALIDATION  != 'true' }}
         uses: gabledata/cicd/github-actions/validate-contracts@latest
         with:
           # Provide API key and endpoint secrets
@@ -26,6 +38,7 @@ jobs:
           contract-paths: |
             ./contracts/*.yaml
       - name: Publish Contracts
+        if: ${{ env.SKIP_VALIDATION  != 'true' }}
         uses: gabledata/cicd/github-actions/publish-contracts@latest
         with:
           # Provide API key and endpoint secrets


### PR DESCRIPTION
Adds an extra step in this repo's workflows to conditionally skip contract validation/publishing if no contracts exist yet. 

The Gable CLI intentionally exits with a non-zero exit code if no contracts are found when calling the validate or publish command. For this tutorial, there won't be any contracts in the repo to start with, so we need this extra step to check if we should skip validation, otherwise the first commit/PR after the repo is forked will have failing contract steps.