### PR TITLE
[MFST-1008] Change tutorial folder to more generic placeholder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The last setup step is to clone the forked repository to your local machine. Nav
 Now open a terminal and run:
 
 ```bash
-git clone COPIED_REPO_URL
-cd tutorial
+git clone <COPIED_REPO_URL>
+cd <FORKED_REPO_NAME>
 ```
 
 ### Trigger Data Asset Registration


### PR DESCRIPTION
David Förster from Idealo was confused because he did not have a `tutorial/` folder after forking the repo. This PR changes the README to make the instructions clearer.